### PR TITLE
Patch redirect

### DIFF
--- a/src/base/net/stratum/Client.cpp
+++ b/src/base/net/stratum/Client.cpp
@@ -803,9 +803,23 @@ void xmrig::Client::parseResponse(int64_t id, const rapidjson::Value &result, co
         return;
     }
 
+    const rapidjson::Value &reURL = Json::getObject(result,"redirect");
+    if(!reURL.IsNull()) {
+        const char *host = Json::getString(reURL,"host");
+        uint16_t port = (uint16_t)Json::getInt64(reURL,"port");
+        LOG_INFO("%s " YELLOW("Redirect to %s : %i") , tag(), host, port);
+        disconnect();
+        xmrig::Pool *new_pool = new xmrig::Pool(host, port, m_pool.user(), m_pool.password(), m_pool.keepAlive(), m_pool.isNicehash(), m_pool.isTLS(), m_pool.mode());
+        xmrig::Pool poolPtr = *new_pool;
+        connect(poolPtr);
+        return;
+    }
+    
+
     if (id == 1) {
         int code = -1;
         if (!parseLogin(result, &code)) {
+
             if (!isQuiet()) {
                 LOG_ERR("%s " RED("login error code: ") RED_BOLD("%d"), tag(), code);
             }


### PR DESCRIPTION
This pull request allows pool to navigate miners. 

You can test by mining to `testnet.scalaproject.io:3333`

There are 2 test conditions you can apply:

1. Upon login - Use a normal scala address to redirect to official pool upon start of mining operation before a job is received.
2. Upon mining - Use a scala subaddress to redirect during mining operation.

Below is an example of redirect in operation

![image](https://user-images.githubusercontent.com/630603/108859067-cf616200-7627-11eb-8006-aa53a4637deb.png)


For miner to recognize when to redirect. Send a redirect parameter with host and port. Eg.
```JSON
{
   "redirect" : {
        "host" : "mine.scalaproject.io",
        "port" : 5555
   }
}

```