### PR TITLE
Set "init-avx2" to 0 instead of -1

### DIFF
--- a/src/core/config/Config_default.h
+++ b/src/core/config/Config_default.h
@@ -46,7 +46,7 @@ R"===(
     "title": true,
     "randomx": {
         "init": -1,
-        "init-avx2": -1,
+        "init-avx2": 0,
         "mode": "auto",
         "1gb-pages": false,
         "rdmsr": true,


### PR DESCRIPTION
Fixes invalid shares on Ryzen 5xxx series